### PR TITLE
fix: import note admin to show up properly in django admin

### DIFF
--- a/chained_notes/adapters/database/admin/__init__.py
+++ b/chained_notes/adapters/database/admin/__init__.py
@@ -1,0 +1,1 @@
+from .note_admin import NoteAdmin as NoteAdmin


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/0e7032a4-b40a-451f-a853-a76fc925ca64)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced direct access to the `NoteAdmin` class from the admin package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->